### PR TITLE
Python3 compatibility

### DIFF
--- a/branchio/__init__.py
+++ b/branchio/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # BranchIo
 # Copyright Headquarters HQ
 # See LICENSE for details.
@@ -9,5 +10,5 @@ __version__ = '0.1.0'
 __author__ = 'Eric Chapman'
 __license__ = 'MIT'
 
-from client import Client
-from defines import *
+from .client import Client
+from .defines import *

--- a/branchio/client.py
+++ b/branchio/client.py
@@ -1,8 +1,16 @@
 import json
+import sys
 try:
     from urllib.request import Request, urlopen
 except ImportError:
     from urllib2 import Request, urlopen
+
+if sys.version_info < (3,):
+    text_type = unicode
+    binary_type = str
+else:
+    text_type = str
+    binary_type = bytes
 
 
 class Client(object):
@@ -87,20 +95,20 @@ class Client(object):
 
         # Check Params
         self._check_param("data", data, params, type=dict)
-        self._check_param("alias", alias, params, type=(str, unicode))
+        self._check_param("alias", alias, params, type=(binary_type, text_type))
         self._check_param("type", type, params, type=int, lte=2, gte=0)
         self._check_param("duration", duration, params, type=int)
-        self._check_param("identity", identity, params, type=(str, unicode), max_length=127)
-        self._check_param("tags", tags, params, type=list, sub_type=(str, unicode), sub_max_length=64)
-        self._check_param("campaign", campaign, params, type=(str, unicode), max_length=128)
-        self._check_param("feature", feature, params, type=(str, unicode), max_length=128)
-        self._check_param("channel", channel, params, type=(str, unicode), max_length=128)
-        self._check_param("stage", stage, params, type=(str, unicode), max_length=128)
+        self._check_param("identity", identity, params, type=(binary_type, text_type), max_length=127)
+        self._check_param("tags", tags, params, type=list, sub_type=(binary_type, text_type), sub_max_length=64)
+        self._check_param("campaign", campaign, params, type=(binary_type, text_type), max_length=128)
+        self._check_param("feature", feature, params, type=(binary_type, text_type), max_length=128)
+        self._check_param("channel", channel, params, type=(binary_type, text_type), max_length=128)
+        self._check_param("stage", stage, params, type=(binary_type, text_type), max_length=128)
 
         if skip_api_call is True:
             return params
         else:
-            self._check_param("branch_key", self.branch_key, params, optional=False, type=(str, unicode))
+            self._check_param("branch_key", self.branch_key, params, optional=False, type=(binary_type, text_type))
             return self.make_api_call(method, url, json_params=params)
 
     def create_deep_linking_urls(self, url_params):

--- a/branchio/client.py
+++ b/branchio/client.py
@@ -130,7 +130,7 @@ class Client(object):
         url = self.BRANCH_BASE_URI+url
 
         if self.verbose is True:
-            print "Making web request: "+url
+            print("Making web request: {}".format(url))
 
         if json_params is not None:
             encoded_params = json.dumps(json_params)
@@ -140,7 +140,7 @@ class Client(object):
             headers = {}
 
         if encoded_params is not None and self.verbose is True:
-            print "Params: "+encoded_params
+            print("Params: {}".format(encoded_params))
 
         request = urllib2.Request(url, encoded_params, headers)
         request.get_method = lambda: method

--- a/branchio/client.py
+++ b/branchio/client.py
@@ -1,5 +1,8 @@
-import urllib2
 import json
+try:
+    from urllib.request import Request, urlopen
+except ImportError:
+    from urllib2 import Request, urlopen
 
 
 class Client(object):
@@ -142,7 +145,7 @@ class Client(object):
         if encoded_params is not None and self.verbose is True:
             print("Params: {}".format(encoded_params))
 
-        request = urllib2.Request(url, encoded_params, headers)
+        request = Request(url, encoded_params, headers)
         request.get_method = lambda: method
-        response = urllib2.urlopen(request).read()
+        response = urlopen(request).read()
         return json.loads(response)

--- a/branchio/client.py
+++ b/branchio/client.py
@@ -153,7 +153,7 @@ class Client(object):
         if encoded_params is not None and self.verbose is True:
             print("Params: {}".format(encoded_params))
 
-        request = Request(url, encoded_params, headers)
+        request = Request(url, encoded_params.encode('utf-8'), headers)
         request.get_method = lambda: method
         response = urlopen(request).read()
-        return json.loads(response)
+        return json.loads(response.decode('utf-8'))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -86,8 +86,8 @@ class ClientCheckApiTests(unittest.TestCase):
     def get_client(self, return_value):
         branch_key = os.environ.get('BRANCH_IO_KEY')
         if branch_key is None:
-            print "WARNING!  Environment variable 'BRANCH_IO_KEY' is not defined." + \
-                  "  Branch API Tests will return stubbed responses."
+            print("WARNING!  Environment variable 'BRANCH_IO_KEY' is not defined."
+                  "  Branch API Tests will return stubbed responses.")
             branch_key = "FAKE KEY"
             branchio.Client.make_api_call = mock.MagicMock(return_value=return_value)
 


### PR DESCRIPTION
Tested by running tests under Python 2.7.9 and Python 3.4.3, with and without the BRANCH_IO_KEY set.

``` bash
mkvirtualenv pythonbranchio_py3 --python=$HOME/.pyenv/versions/3.4.3/bin/python
pip install -r test_requirements.txt
coverage run --source branchio/ -m unittest discover
BRANCH_IO_KEY=my_branch_io_key coverage run --source branchio/ -m unittest discover
```

``` bash
mkvirtualenv pythonbranchio_py2 --python=$HOME/.pyenv/versions/2.7.9/bin/python
pip install -r test_requirements.txt
coverage run --source branchio/ -m unittest discover
BRANCH_IO_KEY=my_branch_io_key coverage run --source branchio/ -m unittest discover
```

It looks like circle.yml could be updated to run the tests against Python 3, but I'm not familiar with how to make that change, nor do I have the means to test it.
